### PR TITLE
Remove timeout flag from example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example Sensu Go handler definition:
     },
     "spec": {
         "type": "pipe",
-        "command": "sensu-relay-handler --api-url http://127.0.0.1:3031/events --disable-check-handling --timeout 10",
+        "command": "sensu-relay-handler --api-url http://127.0.0.1:3031/events --disable-check-handling",
         "timeout": 12
     }
 }


### PR DESCRIPTION
As the timeout flag isn't implemented yet (or is it even needed?), this causes the hander to throw an error and not properly work.